### PR TITLE
prevent event leaks #12

### DIFF
--- a/index.js
+++ b/index.js
@@ -143,6 +143,7 @@ var integrateSignals = function (valueToSet, iface, signalKeys) {
   if(signalKeys.length > 0) {
     var emitter = new events.EventEmitter();
     valueToSet = extend(valueToSet, emitter);
+    iface.removeAllListeners(); //lets just assume that we'll have no more than one instance of any interface
     signalKeys.forEach(function(signalKey) {
       iface.on(signalKey, function() {
 


### PR DESCRIPTION
So the problem is:
- dbus lib caches it's interface objects, always returns the same object for the same service name + object -path + interface name
- node-networkmanger creates its own interface objects that subscribe to dbus lib interface objects, but does not cache them.
- every time finchley wants to update access point list, it gets an array of new instances of node-networkmanager created access point ifaces, which each subscribe to the same dbus iface as the previous instance of same access point

Finchley only ever uses one instance of any interface, so the easiest solution is to unsubscribe previous  listeners when creating a new instance.

It's not very pretty though.. Would be neater to implement caching similar to dbus lib, but thats more work and testing for no immediate gain
